### PR TITLE
fix: iPhone X的分类条很容易误触

### DIFF
--- a/JavBus/JavBus.js
+++ b/JavBus/JavBus.js
@@ -444,7 +444,7 @@ function searchView(height, catname, cols = 3, spa = 1) {
       layout: function(make) {
         //      make.left.right.inset(120)
         make.centerX.equalTo()
-        make.bottom.inset(20)
+        make.bottom.inset(50)
         make.height.equalTo(22)
         //make.width.equalTo(40)
       },

--- a/JavBus/JavBus.js
+++ b/JavBus/JavBus.js
@@ -2781,13 +2781,13 @@ function getAvglePreview(keyword) {
         return
       }
       let video_num = resp.data.response.total_videos
+      let infos = resp.data.response.videos;
       //      $console.log(video_num)
-      if (video_num == 0) {
+      if (video_num == 0 || infos.length === 0) {
         $ui.error("☹️ 暂无视频资源！");
         $ui.loading(false);
         return
       }
-      let infos = resp.data.response.videos;
       let videoUrl = infos[0].preview_video_url
       $("detailView").add({
         type: "video",


### PR DESCRIPTION
fix: iPhone X的分类条很容易误触

另外有一个bug
收藏uncensored的时候很有可能收藏到错误的数据 
actress的un字段为空 
具体是点击影片然后收藏女友
点击影片的时候并不知道是否uncensored
比如 getDetail 方法中 https://www.javbus.com/MKD-S144 能否从这个链接更新uncensored字段?